### PR TITLE
fix cli auth

### DIFF
--- a/lib/armrest/api/auth/cli.rb
+++ b/lib/armrest/api/auth/cli.rb
@@ -25,12 +25,14 @@ module Armrest::Api::Auth
     # Looks like az account get-access-token caches the toke in ~/.azure/accessTokens.json
     # and will update it only when it expires. So dont think we need to handle caching
     def get_access_token
-      command = "az account get-access-token -o json --resource #{resource}"
+      command = "az account get-access-token -o json"
       logger.debug "command: #{command}"
       out = `#{command}`
-      JSON.load(out)
-    rescue
-      raise CliError, 'Error acquiring token from the Azure az CLI'
+      if $?.success?
+        JSON.load(out)
+      else
+        raise CliError, 'Error acquiring token from the Azure az CLI'
+      end
     end
   end
 end

--- a/lib/armrest/auth.rb
+++ b/lib/armrest/auth.rb
@@ -41,7 +41,6 @@ module Armrest
     end
 
     def cli_credentials
-      return unless File.exist?("#{ENV['HOME']}/.azure/accessTokens.json")
       Armrest::Api::Auth::CLI.new(@options)
     end
   end


### PR DESCRIPTION
Fix CLI auth. 

* Remove the File.exist accessTokens.json check
* Update command to `az account get-access-token -o json` without the `--resource` option

## Testing Notes

Tested the CLI auth flow:

    $ exe/armrest auth cli
    {
      "access_token": "bleh",
      "expires_on": 1703173056,
      "subscription": "EXAMPLE-1234-5678-9012-EXAMPLE",
      "tenant": "EXAMPLE",
      "token_type": "Bearer"
    }

Also tested the app auth flow:

    $ exe/armrest auth app
    {
      "token_type": "Bearer",
      "expires_in": "3599",
      "ext_expires_in": "3599",
      "expires_on": "1703172804",
      "not_before": "1703168904",
      "resource": "https://management.azure.com",
      "access_token": "blah"
    }

Closes #3 #4