### PR TITLE
cli auth scope for vault secrets

### DIFF
--- a/lib/armrest/api/auth/cli.rb
+++ b/lib/armrest/api/auth/cli.rb
@@ -22,10 +22,12 @@ module Armrest::Api::Auth
       data.deep_transform_keys { |k| k.underscore } # to normalize the structure to the other classes
     end
 
-    # Looks like az account get-access-token caches the toke in ~/.azure/accessTokens.json
-    # and will update it only when it expires. So dont think we need to handle caching
+    # The az cli command itself has it's own caching. So dont think we need to handle caching
     def get_access_token
       command = "az account get-access-token -o json"
+      if resource.include?("vault.azure.net")
+        command += " --scope https://vault.azure.net/.default"
+      end
       logger.debug "command: #{command}"
       out = `#{command}`
       if $?.success?


### PR DESCRIPTION
Closes #7

Some notes for posterity:

* Only took a quick look at this based on #7
* It looks like the other auth provider strategies support a "resource/scope" already. 
* https://github.com/boltops-tools/armrest/blob/af56b66d782e401e7e3e6c4a6d29b3fecbc8b1e0/lib/armrest/api/auth/login.rb#L13
* https://github.com/boltops-tools/armrest/blob/af56b66d782e401e7e3e6c4a6d29b3fecbc8b1e0/lib/armrest/api/auth/metadata.rb#L30
* The `resource` method comes from https://github.com/boltops-tools/armrest/blob/af56b66d782e401e7e3e6c4a6d29b3fecbc8b1e0/lib/armrest/api/settings.rb#L17
* So was able to use the `resource` method in the CLI auth provider strategy also.
* It looks like the [terraspace_plugin_azurerm](https://github.com/boltops-tools/terraspace_plugin_azurerm) really only has a helper for the [azure_secret](https://terraspace.cloud/docs/helpers/azure/secrets/) right now. So just accounting for the `--scope https://vault.azure.net/.default` for now. 
* Unsure what the general `--scope` option would be for others. If others know what they are, let me know or others know so the code can be more generalized.