### PR TITLE
Add OIDC authentication provider and update changelog for 0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [0.2.3] - 2025-03-29
+- Add federated workload identity support via OIDC auth provider.
+
 ## [0.2.2] - 2023-12-31
 - [#8](https://github.com/boltops-tools/armrest/pull/8) cli auth scope for vault secrets
 

--- a/README.md
+++ b/README.md
@@ -35,38 +35,70 @@ Refer to the [boltops-tools/terraspace_plugin_azurerm](https://github.com/boltop
 
 ## Usage: CLI
 
-The main purpose of gem is to be a Ruby library that Terraspace can interact with.  The CLI interface was only built to help quickly test the code with live resources. It's essentially a way to QA.  Here are some examples:
+The main purpose of gem is to be a Ruby library that Terraspace can interact with. The CLI interface was only built to help quickly test the code with live resources. It's essentially a way to QA. Here are some examples:
 
 Auth:
 
+```shell
     armrest auth app
     armrest auth msi
     armrest auth cli
+    armrest auth oidc
+```
 
-The auth chain is: app -> msi -> cli
+The auth chain is: app -> msi -> cli -> oidc
 
-    armrest auth
+You can disable MSI with `ARMREST_DISABLE_MSI=1`, and you can also enable or disable OIDC explicitly using environment variables (`ARM_USE_OIDC` or `AZURE_USE_OIDC`).
 
-You can disable MSI with `ARMREST_DISABLE_MSI=1`.
+### OIDC Authentication
+
+The OIDC authentication provider allows you to authenticate using OpenID Connect tokens. This is particularly useful for environments like GitHub Actions or Azure DevOps pipelines.
+
+#### Configuration
+
+You can configure OIDC authentication using the following environment variables:
+
+* `ARM_OIDC_TOKEN` or `AZURE_OIDC_TOKEN`: Directly provide the OIDC token.
+* `ARM_OIDC_TOKEN_FILE_PATH` or `AZURE_OIDC_TOKEN_FILE_PATH`: Path to a file containing the OIDC token.
+* `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`: GitHub Actions OIDC credentials.
+* `SYSTEM_OIDCREQUESTURI` and `SYSTEM_ACCESSTOKEN`: Azure DevOps OIDC credentials.
+
+#### Example
+
+To use OIDC authentication, set the required environment variables and run:
+
+```shell
+    armrest auth oidc
+```
+
+This will acquire an OIDC token and exchange it for an Azure access token.
 
 Resource Group:
 
+```shell
     armrest resource_group check_existence demo
+```
 
 Storage Account:
 
+```shell
     armrest storage_account create demofoobar123v3 --tags name:bob age:8
+```
 
 Blob Service:
 
+```shell
     armrest blob_service set_properties --storage-account demofoobar123 --delete-retention-policy days:9 enabled:true --container-delete-retention-policy days:10 enabled:true --is-versioning-enabled
+```
 
 Secret:
 
+```shell
     $ export ARMREST_VAULT=demo-dev-vault-test1
     $ armrest secret show demo-dev-pass
     secret1
     $
+```
 
 ## Installation
 
@@ -74,4 +106,6 @@ Add to your Gemfile
 
 Gemfile
 
+```shell
     gem "armrest"
+```

--- a/lib/armrest/api/auth/base.rb
+++ b/lib/armrest/api/auth/base.rb
@@ -1,4 +1,8 @@
 module Armrest::Api::Auth
   class Base < Armrest::Api::Base
+    # Add OIDC to the auth provider chain
+    def self.providers
+      @providers ||= [Login, OIDC, MSI, AZ]
+    end
   end
 end

--- a/lib/armrest/api/auth/oidc.rb
+++ b/lib/armrest/api/auth/oidc.rb
@@ -1,0 +1,201 @@
+module Armrest::Api::Auth
+  # OIDC authentication provider for Azure
+  class OIDC < Base
+    include Armrest::Logging
+
+    # Check if OIDC authentication is configured via environment variables
+    def self.configured?
+      # Check for ARM_USE_OIDC explicit flag
+      use_oidc = ENV['ARM_USE_OIDC'] || ENV['AZURE_USE_OIDC']
+      use_oidc = use_oidc.downcase if use_oidc
+      case use_oidc
+      when 'false' then return false
+      when 'true'  then return true
+      when nil
+        # Check for direct OIDC token
+        return true if ENV['ARM_OIDC_TOKEN'] || ENV['AZURE_OIDC_TOKEN']
+        return true if ENV['ARM_OIDC_TOKEN_FILE_PATH'] || ENV['AZURE_OIDC_TOKEN_FILE_PATH']
+
+        # Check for GitHub Actions OIDC credentials
+        return true if ENV['ACTIONS_ID_TOKEN_REQUEST_URL'] && ENV['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
+        return true if ENV['ARM_OIDC_REQUEST_URL'] && ENV['ARM_OIDC_REQUEST_TOKEN']
+
+        # Check for Azure DevOps OIDC credentials
+        return true if ENV['SYSTEM_OIDCREQUESTURI'] && ENV['SYSTEM_ACCESSTOKEN']
+
+        false
+      else
+        logger.warn "Unrecognized OIDC flag value: #{use_oidc}"
+      end
+    end
+
+    # Initialize with required Azure credentials
+    def initialize(options = {})
+      super
+      @client_id = options[:client_id] || ENV['ARM_CLIENT_ID'] || ENV['AZURE_CLIENT_ID']
+      @tenant_id = options[:tenant_id] || ENV['ARM_TENANT_ID'] || ENV['AZURE_TENANT_ID']
+      @subscription_id = options[:subscription_id] || ENV['ARM_SUBSCRIPTION_ID'] || ENV['AZURE_SUBSCRIPTION_ID']
+      
+      # Service connection ID for Azure DevOps
+      @service_connection_id = options[:service_connection_id] || 
+                                ENV['ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID'] || 
+                                ENV['ARM_OIDC_AZURE_SERVICE_CONNECTION_ID']
+      
+      # Debug logging
+      logger.debug "Initialized OIDC Auth Provider with client_id: #{@client_id}, tenant_id: #{@tenant_id}"
+    end
+
+    # Get the authentication token
+    def token
+      @token ||= acquire_token
+    end
+
+    # Get the credentials
+    def creds
+      return @creds if @creds
+      token_info = acquire_token
+      @creds = {
+        'access_token' => token_info['access_token'],
+        'expires_on'   => (Time.now.to_i + token_info['expires_in'].to_i).to_s,
+        'token_type'   => token_info['token_type'] || 'Bearer'
+      }
+    end
+
+    private
+
+    # Acquire token using OIDC flow
+    def acquire_token
+      # First, try to get the OIDC token from various sources
+      oidc_token = get_oidc_token
+      
+      unless oidc_token
+        raise Armrest::Error, "Failed to acquire OIDC token from any source"
+      end
+
+      # Exchange OIDC token for an Azure access token
+      exchange_token_for_access_token(oidc_token)
+    end
+
+    # Get OIDC token from various sources
+    def get_oidc_token
+      # Try direct token
+      return ENV['ARM_OIDC_TOKEN'] || ENV['AZURE_OIDC_TOKEN'] if ENV['ARM_OIDC_TOKEN'] || ENV['AZURE_OIDC_TOKEN']
+      
+      # Try token file
+      token_file = ENV['ARM_OIDC_TOKEN_FILE_PATH'] || ENV['AZURE_OIDC_TOKEN_FILE_PATH']
+      if token_file && File.exist?(token_file)
+        begin
+          return File.read(token_file).strip
+        rescue => e
+          logger.error "Failed to read token file: #{e.message}"
+          return nil
+        end
+      end
+      
+      # Try GitHub Actions
+      if ENV['ACTIONS_ID_TOKEN_REQUEST_URL'] && ENV['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
+        return request_github_actions_token
+      end
+      
+      # Try custom request URL/token
+      if ENV['ARM_OIDC_REQUEST_URL'] && ENV['ARM_OIDC_REQUEST_TOKEN']
+        return request_token_from_provider(
+          ENV['ARM_OIDC_REQUEST_URL'],
+          ENV['ARM_OIDC_REQUEST_TOKEN']
+        )
+      end
+      
+      # Try Azure DevOps
+      if ENV['SYSTEM_OIDCREQUESTURI'] && ENV['SYSTEM_ACCESSTOKEN']
+        return request_token_from_provider(
+          ENV['SYSTEM_OIDCREQUESTURI'],
+          ENV['SYSTEM_ACCESSTOKEN']
+        )
+      end
+      
+      nil
+    end
+
+    # Request token from GitHub Actions
+    def request_github_actions_token
+      request_token_from_provider(
+        ENV['ACTIONS_ID_TOKEN_REQUEST_URL'],
+        ENV['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
+      )
+    end
+
+    # Generic function to request a token from a provider
+    def request_token_from_provider(url, token)
+      require 'net/http'
+      require 'json'
+      require 'uri'
+      
+      uri = URI.parse(url)
+      unless uri.scheme == 'https'
+        logger.error "Insecure request URL detected: #{url}"
+        return nil
+      end
+      
+      request = Net::HTTP::Get.new(uri)
+      request['Authorization'] = "Bearer #{token}"
+      request['Accept'] = 'application/json'
+      
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.request(request)
+      end
+      
+      if response.is_a?(Net::HTTPSuccess)
+        json_response = JSON.parse(response.body)
+        return json_response['value']
+      else
+        logger.error "Failed to get OIDC token: #{response.code} - #{response.body}"
+        nil
+      end
+    end
+
+    # Exchange OIDC token for Azure access token
+    def exchange_token_for_access_token(oidc_token)
+      require 'net/http'
+      require 'json'
+      require 'uri'
+      
+      token_endpoint = "https://login.microsoftonline.com/#{@tenant_id}/oauth2/v2.0/token"
+      
+      uri = URI.parse(token_endpoint)
+      request = Net::HTTP::Post.new(uri)
+      request['Content-Type'] = 'application/x-www-form-urlencoded'
+      
+      # Prepare form data
+      form_data = {
+        'client_id' => @client_id,
+        'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+        'client_assertion' => oidc_token,
+        'grant_type' => 'client_credentials',
+        'scope' => 'https://management.azure.com/.default'
+      }
+      
+      # Add service connection ID for Azure DevOps if available
+      form_data['service_connection_id'] = @service_connection_id if @service_connection_id
+      
+      request.set_form_data(form_data)
+      
+      # Debug logging
+      logger.debug "Exchanging OIDC token for access token with endpoint: #{token_endpoint}"
+      
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.request(request)
+      end
+      
+      if response.is_a?(Net::HTTPSuccess)
+        json_response = JSON.parse(response.body)
+        logger.debug "Received access token (expires in #{json_response['expires_in']} seconds)"
+        # Return the entire JSON so the caller can read token_type, expires_in, etc.
+        return json_response
+      else
+        error_message = "Failed to exchange OIDC token: #{response.code} - #{response.body}"
+        logger.error error_message
+        raise Armrest::Error, error_message
+      end
+    end
+  end
+end

--- a/lib/armrest/api/auth/oidc.rb
+++ b/lib/armrest/api/auth/oidc.rb
@@ -12,18 +12,7 @@ module Armrest::Api::Auth
       when 'false' then return false
       when 'true'  then return true
       when nil
-        # Check for direct OIDC token
-        return true if ENV['ARM_OIDC_TOKEN'] || ENV['AZURE_OIDC_TOKEN']
-        return true if ENV['ARM_OIDC_TOKEN_FILE_PATH'] || ENV['AZURE_OIDC_TOKEN_FILE_PATH']
-
-        # Check for GitHub Actions OIDC credentials
-        return true if ENV['ACTIONS_ID_TOKEN_REQUEST_URL'] && ENV['ACTIONS_ID_TOKEN_REQUEST_TOKEN']
-        return true if ENV['ARM_OIDC_REQUEST_URL'] && ENV['ARM_OIDC_REQUEST_TOKEN']
-
-        # Check for Azure DevOps OIDC credentials
-        return true if ENV['SYSTEM_OIDCREQUESTURI'] && ENV['SYSTEM_ACCESSTOKEN']
-
-        false
+        return false
       else
         logger.warn "Unrecognized OIDC flag value: #{use_oidc}"
       end

--- a/lib/armrest/auth.rb
+++ b/lib/armrest/auth.rb
@@ -24,6 +24,7 @@ module Armrest
       else # full chain
         [
           :app_credentials,
+          :oidc_credentials,
           :msi_credentials,
           :cli_credentials,
         ]
@@ -32,7 +33,14 @@ module Armrest
 
     def app_credentials
       return unless ENV['ARM_CLIENT_ID'] || ENV['AZURE_CLIENT_ID']
-      Armrest::Api::Auth::Login.new(@options)
+      login = Armrest::Api::Auth::Login.new(@options)
+      return unless login.respond_to?(:available?) && login.available?
+      login
+    end
+
+    def oidc_credentials
+      return unless Armrest::Api::Auth::OIDC.configured?
+      Armrest::Api::Auth::OIDC.new(@options)
     end
 
     def msi_credentials

--- a/lib/armrest/auth.rb
+++ b/lib/armrest/auth.rb
@@ -33,9 +33,8 @@ module Armrest
 
     def app_credentials
       return unless ENV['ARM_CLIENT_ID'] || ENV['AZURE_CLIENT_ID']
-      login = Armrest::Api::Auth::Login.new(@options)
-      return unless login.respond_to?(:available?) && login.available?
-      login
+      return if ENV['ARM_USE_OIDC'] == 'true'
+      Armrest::Api::Auth::Login.new(@options)
     end
 
     def oidc_credentials

--- a/lib/armrest/autoloader.rb
+++ b/lib/armrest/autoloader.rb
@@ -9,7 +9,7 @@ module Armrest
       end
 
       def self.camelize_map
-        { cli: "CLI", msi: "MSI", version: "VERSION" }
+        { cli: "CLI", oidc: "OIDC", msi: "MSI", version: "VERSION" }
       end
     end
 

--- a/lib/armrest/cli.rb
+++ b/lib/armrest/cli.rb
@@ -23,7 +23,7 @@ module Armrest
     long_desc Help.text(:storage_account)
     subcommand "storage_account", StorageAccount
 
-    desc "auth [TYPE]", "Auth to Azure API. When type is not provided the full credentials chain is checked"
+    desc "auth [TYPE]", "Auth to Azure API. When TYPE is not provided, the full credentials chain is checked. Available TYPEs: app, msi, cli, oidc."
     long_desc Help.text(:auth)
     def auth(type=nil)
       Auth.new(options.merge(type: type)).run

--- a/lib/armrest/cli/help/auth.md
+++ b/lib/armrest/cli/help/auth.md
@@ -1,0 +1,9 @@
+## Examples
+
+    armrest auth
+    armrest auth app
+    armrest auth msi
+    armrest auth cli
+    armrest auth oidc
+
+When using "armrest auth oidc", the OIDC provider is used if configured. Otherwise, it will report "Unable to authenticate".

--- a/lib/armrest/version.rb
+++ b/lib/armrest/version.rb
@@ -1,3 +1,3 @@
 module Armrest
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Adding the OIDC authentication provider which is currently a blocking issue for auto generate backend for tfstate.
The current version of armrest gem (0.2.2) doesn't have the OIDC authentication provider so terraspace always failed to create the backend

The code has been mainly generated by AI (Github Copilot)... it got the inspiration from the following Terraform documentation:
[Authenticating using a Service Principal and OpenID Connect](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/service_principal_oidc)

It has been tested through Gitlab CI, and Azure DevOPS pipeline

Azure Service Principal / OIDC auth is the most secure way to manage your Azure Cloud environment as you don't need to handle any secret